### PR TITLE
add `GoAWSConfig` constructor, improve coverage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoAWS"
 uuid = "00b10cec-568b-4d01-83ea-8604cd7f25ae"
 authors = ["Beacon Biosignals", "Inc."]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/server.jl
+++ b/src/server.jl
@@ -125,10 +125,13 @@ function with_go_aws(f; address=DEFAULT_ADDRESS, region="us-east-2", kw...)
     try
         run(server; wait=false)
         sleep(0.5)  # give the server just a bit of time, though it is very fast to start
-        config = GoAWSConfig(address, region)
+        config = GoAWSConfig(server)
         f(config)
     finally
         # Make sure we kill the server even if a test failed.
         kill(server)
     end
 end
+
+# Helper to create a config from a server directly
+GoAWSConfig(s::Server) = GoAWSConfig(; endpoint=s.address, s.region)


### PR DESCRIPTION
I accidentally pushed this to `main`, so I pushed a revert then updated repo settings to disallow that even for admins, then cherry-picked the commit here instead. Oops!