### PR TITLE
Bump version for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoAWS"
 uuid = "00b10cec-568b-4d01-83ea-8604cd7f25ae"
 authors = ["Beacon Biosignals", "Inc."]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"


### PR DESCRIPTION
We've registered 1.1 internally without the docstring addition; better register a fresh version rather than have subtle differences between 1.1 internall and in General.