### PR TITLE
Fix compatibility with AWS.jl 1.91+

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,7 @@ jobs:
         shell: julia --color=yes --project {0}
         run: |
           using Pkg
-          Pkg.add(PackageSpec(; name="AWS", version="${{ matrix.aws-jl-version }}");
-                  preserve=PRESERVE_ALL)
+          Pkg.add(PackageSpec(; name="AWS", version="${{ matrix.aws-jl-version }}"))
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,11 +41,11 @@ jobs:
         shell: julia --color=yes --project {0}
         run: |
           using Pkg
-          Pkg.add(PackageSpec(; name="AWS", version="${{ matrix.aws-jl-version }}"))
+          aws_pkg = PackageSpec(; name="AWS", version="${{ matrix.aws-jl-version }}")
+          Pkg.add(aws_pkg)
+          Pkg.pin(aws_pkg)
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: ${{ matrix.aws-jl-version == 'latest' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,30 +13,42 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - AWS.jl ${{ matrix.aws-jl-version }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1'
-          - 'nightly'
+          - "min"
+          - "lts"
+          - "nightly"
         os:
           - ubuntu-latest
         arch:
           - x64
+        aws-jl-version:
+          - "1.63.0"  # Oldest supported version
+          - "latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
+      - name: Set AWS.jl version
+        if: ${{ matrix.aws-jl-version != 'latest' }}
+        shell: julia --color=yes --project {0}
+        run: |
+          using Pkg
+          Pkg.add(PackageSpec(; name="AWS", version="${{ matrix.aws-jl-version }}");
+                  preserve=PRESERVE_ALL)
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: ${{ matrix.aws-jl-version == 'latest' }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
         arch:
           - x64
         aws-jl-version:
-          - "1.63.0"  # Oldest supported version
+          - "1.78.0"  # Oldest supported version
           - "latest"
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 goaws_jll = "a437b02d-256c-57cc-b5c6-817ed6633e35"
 
 [compat]
-AWS = "1.63"
+AWS = "1.78"
 Aqua = "0.7.4"
 Compat = "4.11"
 URIs = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoAWS"
 uuid = "00b10cec-568b-4d01-83ea-8604cd7f25ae"
 authors = ["Beacon Biosignals", "Inc."]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
@@ -10,11 +10,11 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 goaws_jll = "a437b02d-256c-57cc-b5c6-817ed6633e35"
 
 [compat]
-AWS = "1.8 - 1.90"
+AWS = "1.91"
 Aqua = "0.7.4"
 URIs = "1.5"
 YAML = "0.4.9"
-goaws_jll = "0.4.5"
+goaws_jll = "0.5"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,9 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 goaws_jll = "a437b02d-256c-57cc-b5c6-817ed6633e35"
 
 [compat]
-AWS = "1.91"
+AWS = "1.63"
 Aqua = "0.7.4"
+Compat = "4.11"
 URIs = "1.5"
 YAML = "0.4.9"
 goaws_jll = "0.5"
@@ -19,7 +20,8 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test"]
+test = ["Aqua", "Compat", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,19 +54,20 @@ port = 41231
 
     @testset "with_go_aws" begin
         with_go_aws() do aws_config
-            result = parse(SQS.create_queue("my_queue"; aws_config))
-            queue_url = result["CreateQueueResult"]["QueueUrl"]
+            parsed = parse(SQS.create_queue("my_queue"; aws_config))
+            queue_url = parsed["QueueUrl"]
 
-            ret = parse(SQS.send_message("hello", queue_url; aws_config))
-            id = ret["SendMessageResult"]["MessageId"] # looks like a UUID, but isn't documented to be one, so guess we should leave it as a string
+            parsed = parse(SQS.send_message("hello", queue_url; aws_config))
+            id = parsed["MessageId"] # looks like a UUID, but isn't documented to be one, so guess we should leave it as a string
 
-            messages = parse(SQS.receive_message(queue_url, Dict("WaitTimeSeconds" => 1);
+            parsed = parse(SQS.receive_message(queue_url, Dict("WaitTimeSeconds" => 1);
                                                  aws_config))
+            @test length(parsed["Messages"]) == 1
 
-            @test messages["ReceiveMessageResult"]["Message"]["Body"] == "hello"
-            receipt = messages["ReceiveMessageResult"]["Message"]["ReceiptHandle"]
-            @test startswith(receipt, id)
-            SQS.delete_message(queue_url, receipt; aws_config)
+            message = first(parsed["Messages"])
+            @test message["Body"] == "hello"
+            @test startswith(message["ReceiptHandle"], id)
+            SQS.delete_message(queue_url, message["ReceiptHandle"]; aws_config)
 
             return SQS.delete_queue(queue_url; aws_config)
         end


### PR DESCRIPTION
In https://github.com/beacon-biosignals/GoAWS.jl/issues/9 we found that AWS.jl 1.91 was not compatible with GoAWS.jl due to the underlying `goaws` library not supporting JSON APIs. Since we mitigated that issue with a upperbound workaround the `goaws` package now has support for JSON APIs so we can address this issue properly.

Related:
- Switched SQS to using JSON instead of XML: https://github.com/JuliaCloud/AWS.jl/pull/637
- `goaws` PR to support JSON APIs: https://github.com/Admiral-Piett/goaws/pull/288